### PR TITLE
Feature: use band_name when downloading albums

### DIFF
--- a/src/main/kotlin/bandcampcollectiondownloader/core/Args.kt
+++ b/src/main/kotlin/bandcampcollectiondownloader/core/Args.kt
@@ -37,6 +37,10 @@ data class Args(
         @CommandLine.Option(names = ["-e", "--skip-failed-releases"], description = ["Skip releases that fail to download after the specified number of retries."])
         var ignoreFailedReleases: Boolean = false,
 
+        @CommandLine.Option(names = ["-b", "--use-band-name"], description = ["save Releases sorted by band name instead of artist"])
+        var useBandName: Boolean = false,
+
+
         @CommandLine.Option(names = ["-j", "--jobs"], usageHelp = false, description = ["Amount of parallel jobs (threads) to use (default: 4)."])
         var jobs: Int = 4,
 

--- a/src/main/kotlin/bandcampcollectiondownloader/core/Args.kt
+++ b/src/main/kotlin/bandcampcollectiondownloader/core/Args.kt
@@ -37,9 +37,8 @@ data class Args(
         @CommandLine.Option(names = ["-e", "--skip-failed-releases"], description = ["Skip releases that fail to download after the specified number of retries."])
         var ignoreFailedReleases: Boolean = false,
 
-        @CommandLine.Option(names = ["-b", "--use-band-name"], description = ["save Releases sorted by band name instead of artist"])
+        @CommandLine.Option(names = ["-b", "--use-band-name"], description = ["Save Releases sorted by band-name instead of artist. The band-name usually is the name of the account putting a release out and can be found on the right of a page above the follow button."])
         var useBandName: Boolean = false,
-
 
         @CommandLine.Option(names = ["-j", "--jobs"], usageHelp = false, description = ["Amount of parallel jobs (threads) to use (default: 4)."])
         var jobs: Int = 4,

--- a/src/main/kotlin/bandcampcollectiondownloader/core/BandcampAPIConnector.kt
+++ b/src/main/kotlin/bandcampcollectiondownloader/core/BandcampAPIConnector.kt
@@ -50,7 +50,8 @@ class BandcampAPIConnector constructor(private val bandcampUser: String, private
             val title: String,
             val artist: String,
             val download_type: String,
-            val art_id: String
+            val art_id: String,
+            val band_name: String
     )
 
     private data class ParsedStatDownload(

--- a/src/main/kotlin/bandcampcollectiondownloader/core/BandcampCollectionDownloader.kt
+++ b/src/main/kotlin/bandcampcollectiondownloader/core/BandcampCollectionDownloader.kt
@@ -147,6 +147,7 @@ class BandcampCollectionDownloader(private val args: Args, private val io: IO) {
         var releasetitle = digitalItem.title
         var artist = digitalItem.artist
         var releaseUTC: ZonedDateTime? = null
+        var bandName = digitalItem.band_name;
         var releaseYear: CharSequence = "0000"
 
         // Skip preorders
@@ -177,11 +178,23 @@ class BandcampCollectionDownloader(private val args: Args, private val io: IO) {
         // Replace invalid chars by similar unicode chars
         releasetitle = Util.replaceInvalidCharsByUnicode(releasetitle)
         artist = Util.replaceInvalidCharsByUnicode(artist)
+        bandName = Util.replaceInvalidCharsByUnicode(bandName)
 
         // Prepare artist and release folder paths
         val downloadFolderPath = Paths.get("${args.pathToDownloadFolder}")
-        val releaseFolderName = "$releaseYear - $releasetitle"
-        var artistFolderPath = downloadFolderPath.resolve(artist)
+
+        var releaseFolderName: String?
+        var artistFolderPath: Path?
+
+        if (!args.useBandName) {
+            artistFolderPath = downloadFolderPath.resolve(artist)
+            releaseFolderName = "$releaseYear - $releasetitle"
+        } else {
+            artistFolderPath = downloadFolderPath.resolve(bandName)
+            releaseFolderName = "$releaseYear - $artist - $releasetitle"
+        }
+
+
         var releaseFolderPath = artistFolderPath.resolve(releaseFolderName)
 
         // If one of the folders already exists as a file, throw an error

--- a/src/main/kotlin/bandcampcollectiondownloader/core/BandcampCollectionDownloader.kt
+++ b/src/main/kotlin/bandcampcollectiondownloader/core/BandcampCollectionDownloader.kt
@@ -146,8 +146,9 @@ class BandcampCollectionDownloader(private val args: Args, private val io: IO) {
         // Get data (1)
         var releasetitle = digitalItem.title
         var artist = digitalItem.artist
-        var releaseUTC: ZonedDateTime? = null
         var bandName = digitalItem.band_name;
+
+        var releaseUTC : ZonedDateTime? = null
         var releaseYear: CharSequence = "0000"
 
         // Skip preorders


### PR DESCRIPTION
Adding a flag to organize releases by band_name instead of artist when downloading.
This is useful for when downloading stuff from labels releasing albums by many artists,