### PR TITLE
add skip hidden files

### DIFF
--- a/src/main/kotlin/bandcampcollectiondownloader/core/Args.kt
+++ b/src/main/kotlin/bandcampcollectiondownloader/core/Args.kt
@@ -17,6 +17,10 @@ data class Args(
                 ])
         var pathToCookiesFile: Path? = null,
 
+        @CommandLine.Option(names = ["--skip-hidden", "-s"], required = false,
+                description = ["Don't download hidden files (a few hidden files might be present in a cache and be downloaded though)"])
+        var skipHiddenItems: Boolean = false,
+
         @CommandLine.Option(names = ["--audio-format", "-f"], required = false,
                 description = ["The chosen audio format of the files to download (default: \${DEFAULT-VALUE}).", "Possible values: flac, wav, aac-hi, mp3-320, aiff-lossless, vorbis, mp3-v0, alac."])
         var audioFormat: String = "vorbis",

--- a/src/main/kotlin/bandcampcollectiondownloader/core/BandcampCollectionDownloader.kt
+++ b/src/main/kotlin/bandcampcollectiondownloader/core/BandcampCollectionDownloader.kt
@@ -63,7 +63,7 @@ class BandcampCollectionDownloader(private val args: Args, private val io: IO) {
                 // Try to connect to bandcamp with the cookies
                 Util.log("Connecting to Bandcamp…")
                 val candidateConnector =
-                    BandcampAPIConnector(args.bandcampUser, cookies.content, args.timeout, args.retries)
+                    BandcampAPIConnector(args.bandcampUser, cookies.content, args.skipHiddenItems, args.timeout, args.retries)
                 candidateConnector.init()
                 val pageName = candidateConnector.getBandcampPageName()
                 Util.log("""Found "$pageName" with ${candidateConnector.getAllSaleItemIDs().size} items.""")


### PR DESCRIPTION
This resolves #18. 

The problem was that the program was not fetching hidden files. 

From my understanding of the bandcamp API, the reason why you did not manage to debug is the following : 

When you first get the data you get the `collection_data.redownload_urls` field and add it to your little map you'll iterate on later. 
The thing is that field is containing the first batch of collection items *AND* the first batch of hidden items. 
This makes your program downloading the hidden files for collections with a small amount of hidden items but as soon as you have more than 20 items then you need to contact the bandcamp API to fetch more. 

They have `.../hidden_items` route working pretty much like the `.../collection_items` one. 

I took a very naive approach, I added a new `--skip-hidden` flag to the command that would not do the work of fetching the extra hidden items.

What is a bit clumsy is that in any case, if there are items in the first batch of `redownload_urls` I did not do the work of filtering them out if they are hidden. This could be done but it would require a bit more work and as I said yesterday, I am no Kotlin dev, plus I don't really have the time to do this extra work at the moment. That being said, I digged a bit the API on my side and would gladly help you figure out some stuff if need be. 