### PR TITLE
Fix wrong string comparison when finding existing artist/release folders

### DIFF
--- a/src/main/kotlin/bandcampcollectiondownloader/core/BandcampCollectionDownloader.kt
+++ b/src/main/kotlin/bandcampcollectiondownloader/core/BandcampCollectionDownloader.kt
@@ -228,12 +228,12 @@ class BandcampCollectionDownloader(
         // If artist or release folder exists with different case, use it instead of the planned one
         if (Files.isDirectory(downloadFolderPath) && !Files.isDirectory(artistFolderPath)) {
             val candidateArtistFolders = Files.list(downloadFolderPath)
-                .filter { f -> Files.isDirectory(f) && f.fileName.toString().endsWith(artist, true) }
+                .filter { f -> Files.isDirectory(f) && f.fileName.toString().equals(artist, true) }
                 .collect(Collectors.toList())
             if (candidateArtistFolders.isNotEmpty()) {
                 artistFolderPath = candidateArtistFolders[0]
                 val candidateReleaseFolders = Files.list(artistFolderPath)
-                    .filter { f -> Files.isDirectory(f) && f.fileName.toString().endsWith(releaseFolderName, true) }
+                    .filter { f -> Files.isDirectory(f) && f.fileName.toString().equals(releaseFolderName, true) }
                     .collect(Collectors.toList())
                 releaseFolderPath = if (candidateReleaseFolders.isNotEmpty()) {
                     candidateReleaseFolders[0]


### PR DESCRIPTION
The current existing folder check uses endsWith which can result in false positives
eg Downloads from "Lone" getting put in a folder called "Kali Malone"

This pr changes the check to be case insensitive equals.