### PR TITLE
replaceInvalidCharsByUnicode: If final char is a period or space, replace with a lookalike character

### DIFF
--- a/src/main/kotlin/bandcampcollectiondownloader/core/Constants.kt
+++ b/src/main/kotlin/bandcampcollectiondownloader/core/Constants.kt
@@ -15,4 +15,11 @@ object Constants {
             '?' to '？',
             '|' to '∣'
     )
+
+    // On Windows, period and space are allowed, but not at the end of a file/directory name.
+    // See: https://learn.microsoft.com/en-us/windows/win32/fileio/naming-a-file
+    val TRAILING_CHAR_REPLACEMENTS = hashMapOf<Char, Char>(
+            '.' to '․',
+            ' ' to ' ',
+    )
 }

--- a/src/main/kotlin/bandcampcollectiondownloader/util/Util.kt
+++ b/src/main/kotlin/bandcampcollectiondownloader/util/Util.kt
@@ -21,6 +21,13 @@ class Util(private val logger: Logger) {
         for ((old, new) in Constants.UNICODE_CHARS_REPLACEMENTS) {
             result = result.replace(old, new)
         }
+
+        if (result.isNotEmpty()) {
+            if (result.last() in Constants.TRAILING_CHAR_REPLACEMENTS.keys) {
+                result = result.dropLast(1) + Constants.TRAILING_CHAR_REPLACEMENTS[result.last()]
+            }
+        }
+
         return result
     }
 


### PR DESCRIPTION
Addresses https://framagit.org/Ezwen/bandcamp-collection-downloader/-/issues/34

Alternative to https://framagit.org/Ezwen/bandcamp-collection-downloader/-/merge_requests/4

I took some different design decisions than that MR:

- I'm replacing a single trailing space/period unconditionally, rather than conditional on OS being Windows. The thought here is:
  - consistency with the existing UNICODE_CHARS_REPLACEMENTS which is also not conditional on OS
  - It's plausible you'd use bandcamp-collection-downloader on Linux and transfer the resulting archive to Windows, or vice-versa
- rather than deleting trailing spaces/periods, replace only the last character (if it's space or period) with a unicode lookalike
  - space gets mapped to https://www.compart.com/en/unicode/U+2002
  - period gets mapped to https://www.compart.com/en/unicode/U+2024
  - again, this is consistent with the existing approach - unicode lookalikes are already in use
  - by only replacing the last character, rather than deleting, it's a bit simpler because we avoid needing to apply rules repeatedly like in the "p l e a s e s t a n d b y . . ." example

Open questions / possible issues:

If someone on Linux has already downloaded an album ending in "." without issue, and then runs bandcamp-collection-downloader later if this PR is merged, I think that album might get downloaded again?