### PR TITLE
[BUGFIX] fix gradle version in gradle-docker wrapper

### DIFF
--- a/gradle-docker.sh
+++ b/gradle-docker.sh
@@ -3,4 +3,5 @@
 set -e
 set -x
 
-docker run --rm -v $PWD:/workspace:z -w /workspace docker.io/library/gradle:jdk11 gradle $*
+docker run --rm -v $PWD:/workspace:z -w /workspace docker.io/library/gradle:7-jdk11 gradle $*
+


### PR DESCRIPTION
* build fails with gradle 8
* fixed by explicit using of the gradle 7 images

fixes https://github.com/Ezwen/bandcamp-collection-downloader/issues/52