### PR TITLE
Quick and dirty Solution for 429 errors

### DIFF
--- a/gradle-docker.sh
+++ b/gradle-docker.sh
@@ -3,4 +3,5 @@
 set -e
 set -x
 
-docker run --rm -v $PWD:/workspace:z -w /workspace docker.io/library/gradle:jdk11 gradle $*
+docker run --rm -v $PWD:/workspace:z -w /workspace docker.io/library/gradle:7-jdk11 gradle $*
+

--- a/src/main/kotlin/bandcampcollectiondownloader/core/BandcampAPIConnector.kt
+++ b/src/main/kotlin/bandcampcollectiondownloader/core/BandcampAPIConnector.kt
@@ -7,6 +7,8 @@ import org.jsoup.HttpStatusException
 import org.jsoup.Jsoup
 import java.util.*
 import java.util.regex.Pattern
+import java.util.concurrent.TimeUnit
+
 
 class BandcampAPIConnector constructor(
     private val bandcampUser: String,
@@ -166,6 +168,7 @@ class BandcampAPIConnector constructor(
             // Append download pages from this api endpoint as well
             val theRest =
                 util.retry({
+                    TimeUnit.SECONDS.sleep((1 + Random().nextInt(2)).toLong())
                     Jsoup.connect("https://bandcamp.com/api/fancollection/1/${collectionName}")
                         .ignoreContentType(true)
                         .timeout(timeout)

--- a/src/main/kotlin/bandcampcollectiondownloader/core/BandcampCollectionDownloader.kt
+++ b/src/main/kotlin/bandcampcollectiondownloader/core/BandcampCollectionDownloader.kt
@@ -14,6 +14,7 @@ import java.time.temporal.ChronoField
 import java.util.*
 import java.util.concurrent.*
 import java.util.stream.Collectors
+import java.util.concurrent.TimeUnit
 
 class BandcampCollectionDownloader(
     private val args: Command,
@@ -150,7 +151,7 @@ class BandcampCollectionDownloader(
     }
 
     private fun manageDownloadPage(connector: BandcampAPIConnector, saleItemId: String, cache: Cache) {
-
+        TimeUnit.SECONDS.sleep((1 + Random().nextInt(2)).toLong())
         val digitalItem = connector.retrieveDigitalItemData(saleItemId)
 
         // If null, then the download page is simply invalid and not usable anymore, therefore it can be added to the cache


### PR DESCRIPTION
Bandcamp throws 429 http-errors because the tool is acting to fast.
Added random delays while parsing the collection and while downloading.

probably not the most elegant solution but it handles my collection just fine.
