### PR TITLE
[BUGFIX] Fix "File name too long" errors

### DIFF
--- a/src/main/kotlin/bandcampcollectiondownloader/core/Constants.kt
+++ b/src/main/kotlin/bandcampcollectiondownloader/core/Constants.kt
@@ -22,4 +22,7 @@ object Constants {
             '.' to '․',
             ' ' to ' ',
     )
+    val UNICODE_STRING_REPLACEMENTS = hashMapOf<String, String>(
+        "\u200B" to ""
+    )
 }

--- a/src/main/kotlin/bandcampcollectiondownloader/core/Constants.kt
+++ b/src/main/kotlin/bandcampcollectiondownloader/core/Constants.kt
@@ -4,16 +4,17 @@ object Constants {
 
     const val LINESIZE: Int = 130
     const val VERSION: String = "v2021-12-05"
-    val UNICODE_CHARS_REPLACEMENTS = hashMapOf<Char, Char>(
-            ':' to '꞉',
-            '/' to '／',
-            '\\' to '⧹',
-            '"' to '＂',
-            '*' to '⋆',
-            '<' to '＜',
-            '>' to '＞',
-            '?' to '？',
-            '|' to '∣'
+    val UNICODE_CHARS_REPLACEMENTS = hashMapOf<String, String>(
+            ":" to "꞉",
+            "/" to "／",
+            "\\" to "⧹",
+            "\"" to "＂",
+            "*" to "⋆",
+            "<" to "＜",
+            ">" to "＞",
+            "?" to "？",
+            "|" to "∣",
+            "\u200B" to ""
     )
 
     // On Windows, period and space are allowed, but not at the end of a file/directory name.
@@ -21,8 +22,5 @@ object Constants {
     val TRAILING_CHAR_REPLACEMENTS = hashMapOf<Char, Char>(
             '.' to '․',
             ' ' to ' ',
-    )
-    val UNICODE_STRING_REPLACEMENTS = hashMapOf<String, String>(
-        "\u200B" to ""
     )
 }

--- a/src/main/kotlin/bandcampcollectiondownloader/util/Util.kt
+++ b/src/main/kotlin/bandcampcollectiondownloader/util/Util.kt
@@ -20,9 +20,6 @@ open class Util(private val logger: Logger) {
 
     fun replaceInvalidCharsByUnicode(s: String): String {
         var result: String = s
-        for ((old, new) in Constants.UNICODE_STRING_REPLACEMENTS) {
-            result = result.replace(old, new)
-        }
         for ((old, new) in Constants.UNICODE_CHARS_REPLACEMENTS) {
             result = result.replace(old, new)
         }

--- a/src/main/kotlin/bandcampcollectiondownloader/util/Util.kt
+++ b/src/main/kotlin/bandcampcollectiondownloader/util/Util.kt
@@ -20,6 +20,9 @@ open class Util(private val logger: Logger) {
 
     fun replaceInvalidCharsByUnicode(s: String): String {
         var result: String = s
+        for ((old, new) in Constants.UNICODE_STRING_REPLACEMENTS) {
+            result = result.replace(old, new)
+        }
         for ((old, new) in Constants.UNICODE_CHARS_REPLACEMENTS) {
             result = result.replace(old, new)
         }

--- a/src/test/kotlin/bandcampcollectiodownloader/test/UtilTests.kt
+++ b/src/test/kotlin/bandcampcollectiodownloader/test/UtilTests.kt
@@ -1,0 +1,36 @@
+package bandcampcollectiodownloader.test
+
+import bandcampcollectiondownloader.util.Logger
+import bandcampcollectiondownloader.util.Util
+import bandcampcollectiondownloader.core.Constants
+
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+class UtilTest {
+
+    private lateinit var logger: Logger
+    private lateinit var util: Util
+
+    @BeforeEach
+    fun setUp() {
+        logger = Logger(true)
+        util = Util(logger)
+    }
+
+
+    @Test
+    fun testReplaceInvalidCharsByUnicode() {
+        for ((old, new) in Constants.UNICODE_CHARS_REPLACEMENTS) {
+            val input = "Test${old}String"
+            val expected = "Test${new}String"
+            assertEquals(expected, util.replaceInvalidCharsByUnicode(input))
+        }
+        for ((old, new) in Constants.TRAILING_CHAR_REPLACEMENTS) {
+            val input = "Test${old}"
+            val expected = "Test${new}"
+            assertEquals(expected, util.replaceInvalidCharsByUnicode(input))
+        }
+    }
+}


### PR DESCRIPTION
* some artists use ZeroWidthSpace in their names/releases (Why? WTF) which results in file/directory names longer than 255
* solution remove ZeroWidthSpace from artist & releasenames 


fixes https://github.com/Ezwen/bandcamp-collection-downloader/issues/56 for my usecase. 
all my problematic releases are downloading for now.